### PR TITLE
fix: update zebraw-html and reset some styles

### DIFF
--- a/content/zh-CN/news/2025-02/typst-0-13-0-rc-1-released.typ
+++ b/content/zh-CN/news/2025-02/typst-0-13-0-rc-1-released.typ
@@ -47,23 +47,7 @@ Typst 0.13.0, RC 1 版本发布了. changelog 见 #link("https://staging.typst.a
     heading(tags + title, level: 1)
   }
 }
-#let exp-err(code, msg) = {
-  _exp(code, "ERR:\n" + msg)
-}
-#let exp-warn(code, msg) = {
-  _exp(code, eval(code.text, mode: "markup") + "WARN:\n" + msg)
-}
-#let exp-change(code, before, after) = {
-  _exp(
-    code,
-    table(
-      stroke: white,
-      columns: 2,
-      [曾经], [现在],
-      before, after,
-    ),
-  )
-}
+
 
 #align(
   center,
@@ -249,16 +233,16 @@ Typst 0.13.0, RC 1 版本发布了. changelog 见 #link("https://staging.typst.a
 实现了 PDF 输出中无可见注释的文件嵌入功能.
 
 #_exp(
-  ```typ
-  下面的代码会向 PDF 中嵌入一些附件.
-  #pdf.embed("hello.txt")
+```typ
+下面的代码会向 PDF 中嵌入一些附件.
+#pdf.embed("hello.txt")
 
-  可以手动设置多项参数.
-  #pdf.embed("changelog.typ", description: "Source code of this document.", mime-type: "text/plain", relationship: "source")
+可以手动设置多项参数.
+#pdf.embed("changelog.typ", description: "Source code of this document.", mime-type: "text/plain", relationship: "source")
 
-  也可以从 `bytes` 插入, 并且自定义文件名.
-  #let data = read("hello.txt", encoding: none)
-  #pdf.embed("hello2.txt", data)
+也可以从 `bytes` 插入, 并且自定义文件名.
+#let data = read("hello.txt", encoding: none)
+#pdf.embed("hello2.txt", data)
   ```,
   [],
 )

--- a/typ/templates/news.typ
+++ b/typ/templates/news.typ
@@ -61,7 +61,7 @@
         .map(x => html.elem("div", x))
         .join(),
       attrs: {
-        (style: "display: grid; grid-template-columns: 1fr 1fr; gap: 0.5em; ")
+        (style: "display: grid; grid-template-columns: 50% 50%; gap: 0.5em; ")
       },
     ),
   )

--- a/typ/templates/template.typ
+++ b/typ/templates/template.typ
@@ -171,11 +171,12 @@
     highlight-color: blue.lighten(90%),
     comment-color: blue.lighten(93%),
     lang-color: blue.darken(90%),
-    lang: false,
+    lang: true,
   )
   show: zebraw.with(
     block-width: 100%,
     line-width: 100%,
+    wrap: false,
   )
   set raw(theme: "/assets/tokyo-night.tmTheme")
   show raw: set text(fill: rgb("#c0caf5"))


### PR DESCRIPTION
feat from zebraw: with zebraw language tab enabled, user should be able to click at the lang tab to copy the code.